### PR TITLE
chore: librarian release pull request: 20251001T101122Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,11 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
 libraries:
   - id: generator
-    version: 0.53.1
+    version: 0.54.0
+    last_generated_commit: ""
+    apis: []
     source_roots:
       - .
-    tag_format: 'v{version}'
+    preserve_regex: []
+    remove_regex: []
+    tag_format: v{version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## [0.54.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.54.0) (2025-10-01)
+
+### Features
+
+* just a test change ([0af1b0b](https://github.com/googleapis/google-cloud-go/commit/0af1b0b9053c47c5fa5bac17b89f74ac07aabe67))
+
 # Changelog
 
 ## [0.53.1](https://github.com/googleapis/gapic-generator-go/compare/v0.53.0...v0.53.1) (2025-05-30)

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.53.1"
+const Version = "0.54.0"


### PR DESCRIPTION
Librarian Version: v0.1.1-0.20251001021857-725919400de3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
<details><summary>generator: 0.54.0</summary>

## [0.54.0](https://github.com/jskeet/gapic-generator-go/compare/v0.53.1...v0.54.0) (2025-10-01)

### Features

* just a test change ([0af1b0b](https://github.com/jskeet/gapic-generator-go/commit/0af1b0b))

</details>